### PR TITLE
Expose prometheus metrics for #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project helps you keep track of all your software and tools that are used o
 ## Features
 
 -   [x] Keep track of versions of all the running containers (including init containers) inside the Kubernetes
--   [x] Keep track of new image versions. Supporting Quay, Gcr, Docker hub, Jfrog Artifactory by default 
+-   [x] Keep track of new image versions. Supporting Quay, Gcr, Docker hub, Jfrog Artifactory by default
 -   [x] Works with private registries and private images
 -   [x] Allow overriding of the registry to search latest versions from another registry
 -   [x] Keep track of image vulnerabilities using Jfrog Xray
@@ -23,10 +23,11 @@ This project helps you keep track of all your software and tools that are used o
 -   [x] Keep track of Helm chart deployments and track new versions of the charts
 -   [x] Present the information command line
 -   [x] Present the information trough a web UI
+-   [x] Export prometheus metrics
 
 ## Help (how to run)
 
-For all the configuration options please have a look at the [exampleConfig.yaml](exampleConfig.yaml). 
+For all the configuration options please have a look at the [exampleConfig.yaml](exampleConfig.yaml).
 
 When running lcm you can provide certain flags which are not available in the config. The application assumes there is a config.yaml available in the same folder.
 
@@ -46,6 +47,7 @@ Flags:
   --jsonLogging           Log in json format
   --logFile=LOGFILE       Log file path
   --server                Start the server
+  --metrics               Start the metric server (runs on port 9572)
 ```
 
 **Note:** If you are using `--server` option please make sure the `templates` and `static` folder are next to the binary so it can serve the page.
@@ -83,6 +85,14 @@ docker run -it -v $(pwd)/config.yaml:/config.yaml -p 7321:7321 arminc/lcm:latest
 | derailed/popeye     | v0.4.1  |  v0.5.0  |
 | hashicorp/terraform | 0.11.14 | v0.12.18 |
 +---------------------+---------+----------+
+```
+
+### Metric output
+
+```text
+chart_info{chart="polaris",latestVersion="1.1.0",version="0.10.1"} 0
+image_info{image="storageos/csi-provisioner",latestVersion="v1.4.0",registry="docker.io",version="v1.4.0"} 1
+tool_info{latestVersion="v0.12.26",tool="hashicorp/terraform",version="0.11.14"} 0
 ```
 
 ### Web UI

--- a/cmd/lcm/main.go
+++ b/cmd/lcm/main.go
@@ -45,6 +45,7 @@ func initFlags() config.AppConfig {
 	app.Flag("jsonLogging", "Log in json format").BoolVar(&cliFlags.JSONLoggingEnabled)
 	app.Flag("logFile", "Log file path").StringVar(&cliFlags.LogFile)
 	app.Flag("server", "Start the server").BoolVar(&cliFlags.StartServer)
+	app.Flag("metrics", "Start the metrics server").BoolVar(&cliFlags.ExportMetrics)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	return *cliFlags
@@ -56,7 +57,11 @@ func main() {
 	config.CliFlags = cliFlags // Add cli flags to config object
 	initLogging(config)
 	log.WithField("version", version).Info("Running version")
+
 	internal.Execute(config)
+	if config.CliFlags.ExportMetrics {
+		go internal.StartMetricsServer(config)
+	}
 	if config.CliFlags.StartServer {
 		internal.StartServer()
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/franela/goblin v0.0.0-20200409142057-1def193310bb // indirect
 	github.com/gin-gonic/gin v1.6.3 // indirect
-	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/go-github/v28 v28.1.1
 	github.com/google/go-github/v31 v31.0.0
 	github.com/gorilla/mux v1.7.4
 	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40
@@ -23,13 +21,11 @@ require (
 	github.com/stretchr/testify v1.6.0
 	github.com/target/go-arty v0.0.0-20191122155631-9967a6326524
 	github.com/urfave/negroni v1.0.0
-	github.com/xenolf/lego v2.7.2+incompatible
-	go.etcd.io/etcd v3.3.22+incompatible
+	github.com/xenolf/lego v2.7.2+incompatible // indirect
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	google.golang.org/appengine v1.6.6 // indirect
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
-	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.0.1
 	k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
 	k8s.io/client-go v0.0.0-20191016111102-bec269661e48

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/knadh/koanf v0.10.0
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/olekukonko/tablewriter v0.0.4
+	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,21 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
+github.com/Azure/go-autorest/autorest/adal v0.5.0 h1:q2gDruN08/guU9vAjuPWff0+QIrpH6ediguzdAzXAUU=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
+github.com/Azure/go-autorest/autorest/date v0.1.0 h1:YGrhWfrgtFs84+h0o46rJrlmsZtyZRg470CqAXTZaGM=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.2.0 h1:Ww5g4zThfD/6cLb4z6xxgeyDa7QDkizMkJKe0ysZXp0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
+github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VYyQflFE619k=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -97,6 +104,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/deislabs/oras v0.7.0 h1:RnDoFd3tQYODMiUqxgQ8JxlrlWL0/VMKIKRD01MmNYk=
 github.com/deislabs/oras v0.7.0/go.mod h1:sqMKPG3tMyIX9xwXUBRLhZ24o+uT4y6jgBD2RzUTKDM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/cli v0.0.0-20190506213505-d88565df0c2d h1:qdD+BtyCE1XXpDyhvn0yZVcZOLILdj9Cw4pKu0kQbPQ=
 github.com/docker/cli v0.0.0-20190506213505-d88565df0c2d/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -260,6 +268,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZsA=
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=

--- a/go.sum
+++ b/go.sum
@@ -248,10 +248,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
-github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -486,7 +482,6 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 github.com/xenolf/lego v0.0.0-20160613233155-a9d8cec0e656/go.mod h1:fwiGnfsIjG7OHPfOvgK7Y/Qo6+2Ox0iozjNTkZICKbY=
 github.com/xenolf/lego v0.3.2-0.20160613233155-a9d8cec0e656 h1:BTvU+npm3/yjuBd53EvgiFLl5+YLikf2WvHsjRQ4KrY=
 github.com/xenolf/lego v0.3.2-0.20160613233155-a9d8cec0e656/go.mod h1:fwiGnfsIjG7OHPfOvgK7Y/Qo6+2Ox0iozjNTkZICKbY=
-github.com/xenolf/lego v1.2.1 h1:wAsBCIaTDlgYbR/yVuP0gzcnZrA94NVc84K6vfOIyyA=
 github.com/xenolf/lego v2.7.2+incompatible h1:aGxxYqhnQLQ71HsvEAjJVw6ao14APwPpRk0mpFroPXk=
 github.com/xenolf/lego v2.7.2+incompatible/go.mod h1:fwiGnfsIjG7OHPfOvgK7Y/Qo6+2Ox0iozjNTkZICKbY=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -497,9 +492,6 @@ github.com/yvasiyarov/gorelic v0.0.6 h1:qMJQYPNdtJ7UNYHjX38KXZtltKTqimMuoQjNnSVI
 github.com/yvasiyarov/gorelic v0.0.6/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f h1:ERexzlUfuTvpE74urLSbIQW0Z/6hF9t8U4NsJLaioAY=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
-go.etcd.io/etcd v0.5.0-alpha.5 h1:VOolFSo3XgsmnYDLozjvZ6JL6AAwIDu1Yx1y+4EYLDo=
-go.etcd.io/etcd v3.3.22+incompatible h1:6rUh61a1ijB5rJec+KAVzch3RqEnTcdwNizcMEeoSxU=
-go.etcd.io/etcd v3.3.22+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type AppConfig struct {
 	Locally            bool
 	ConfigFile         string
 	StartServer        bool   `koanf:"startServer"`
+	ExportMetrics      bool   `koanf:"exportMetrics"`
 	JSONLoggingEnabled bool   `koanf:"jsonLoggingEnabled"`
 	LogFile            string `koanf:"logFile"`
 	Verbose            bool   `koanf:"verbose"`

--- a/internal/lcm.go
+++ b/internal/lcm.go
@@ -44,13 +44,10 @@ func Execute(config config.Config) {
 	var containers = []kubernetes.Container{}
 	if config.IsKubernetesFetchEnabled() {
 		containers = kubernetes.GetContainersFromNamespaces(config.Namespaces, config.RunningLocally())
-		log.L.WithField("lcm", "FetchEabled").Debugf("Containers are %+v", containers)
 	}
 
 	containers = getExtraImages(config.Images, containers)
-	log.L.WithField("lcm", "InclExtraImages").Debugf("Incl. ExtraContainers are %+v", containers)
 	info := getLatestVersionsForContainers(containers, config.ImageRegistries)
-	log.L.WithField("lcm", "LatestVersionsForContainers").Debugf("Info after getLatestVersionsForContainers%+v", info)
 	if len(config.Xray.URL) > 0 {
 		info = getVulnerabilities(info, config)
 	}

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -35,8 +35,8 @@ var (
 		"latestVersion",
 	})
 	githubStats = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "tool_info",
-		Help: "Information on tool releases",
+		Name: "github_info",
+		Help: "Information on github tool/application releases",
 	}, []string{
 		"tool",
 		"version",
@@ -89,7 +89,7 @@ func runStats(config config.Config) {
 		imageStats.WithLabelValues(image, version, latestVersion, registry).Set(status)
 	}
 
-	// tools images
+	// github released versions
 	github := getLatestVersionsForGitHub(ctx, config.GitHub)
 	for _, item := range github {
 		tool := item.Repo

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -1,0 +1,117 @@
+package internal
+
+import (
+	"github.com/arminc/k8s-platform-lcm/internal/config"
+	"github.com/arminc/k8s-platform-lcm/internal/kubernetes"
+	"github.com/arminc/k8s-platform-lcm/internal/versioning"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	// Import to initialize client auth plugins.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	prometheusHandler = promhttp.Handler()
+	imageStats        = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "image_info",
+		Help: "Information on image releases",
+	}, []string{
+		"image",
+		"version",
+		"latestVersion",
+		"registry",
+	})
+	chartStats = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "chart_info",
+		Help: "Information on chart releases",
+	}, []string{
+		"chart",
+		"version",
+		"latestVersion",
+	})
+	toolStats = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tool_info",
+		Help: "Information on tool releases",
+	}, []string{
+		"tool",
+		"version",
+		"latestVersion",
+	})
+)
+
+func runStats(config config.Config) {
+
+	imageStats.Reset()
+	toolStats.Reset()
+	chartStats.Reset()
+
+	//charts = getLatestVersionsForHelmCharts(config.HelmRegistries, config.Namespaces, config.RunningLocally(), clients)
+	var containers []kubernetes.Container
+	var charts []ChartInfo
+	if config.IsKubernetesFetchEnabled() {
+		containers = kubernetes.GetContainersFromNamespaces(config.Namespaces, config.RunningLocally())
+		charts = getLatestVersionsForHelmCharts(config.HelmRegistries, config.Namespaces, config.RunningLocally())
+	}
+
+	//// charts
+	for _, item := range charts {
+		chart := item.Chart.Name
+		version := item.Chart.Version
+		latestVersion := item.LatestVersion
+		getHighestVersion := versioning.FindHighestVersionInList([]string{version, latestVersion}, true)
+		status := 0.0
+		if version == getHighestVersion {
+			status = 1.0
+		}
+		chartStats.WithLabelValues(chart, version, latestVersion).Set(status)
+	}
+
+	containers = getExtraImages(config.Images, containers)
+	// docker images related
+	containers = getExtraImages(config.Images, containers)
+	info := getLatestVersionsForContainers(containers, config.ImageRegistries)
+	for _, item := range info {
+		image := item.Container.Name
+		registry := item.Container.URL
+		version := item.Container.Version
+		latestVersion := item.LatestVersion
+		getHighestVersion := versioning.FindHighestVersionInList([]string{version, latestVersion}, true)
+		status := 0.0
+		if version == getHighestVersion {
+			status = 1.0
+		}
+		imageStats.WithLabelValues(image, version, latestVersion, registry).Set(status)
+	}
+
+	// tools images
+	tools := getLatestVersionsForTools(config.Tools, config.ToolRegistries)
+	for _, item := range tools {
+		tool := item.Tool.Repo
+		version := item.Tool.Version
+		latestVersion := item.LatestVersion
+		getHighestVersion := versioning.FindHighestVersionInList([]string{version, latestVersion}, true)
+		status := 0.0
+		if version == getHighestVersion {
+			status = 1.0
+		}
+		toolStats.WithLabelValues(tool, version, latestVersion, ).Set(status)
+	}
+}
+
+// StartMetricsServer starts the server
+func StartMetricsServer(config config.Config) {
+
+	http.HandleFunc("/metrics", newStatsHandler(config))
+	log.Fatal(http.ListenAndServe(":9572", nil))
+}
+
+func newStatsHandler(config config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		runStats(config)
+		prometheusHandler.ServeHTTP(w, r)
+	}
+}

--- a/internal/registries/docker.go
+++ b/internal/registries/docker.go
@@ -53,8 +53,6 @@ type ImageRegistry struct {
 	AllowAllReleases bool
 }
 
-var cacheToken = ""
-
 // GetLatestVersion fetches the latest version of the docker image from Docker registry
 func (r ImageRegistry) GetLatestVersion(name string) string {
 	log.WithField("registry", r.Name).WithField("image", name).Debug("Get latest version for Docker image")
@@ -64,10 +62,10 @@ func (r ImageRegistry) GetLatestVersion(name string) string {
 		name = "library/" + name
 	}
 
-	cacheToken = "" // reset the token
+	cacheToken := "" // reset the token
 
 	pathSuffix := fmt.Sprintf("/v2/%s/tags/list", name)
-	tags, err := r.fetch(pathSuffix)
+	tags, err := r.fetch(pathSuffix, cacheToken)
 	if err != nil {
 		log.WithError(err).WithField("name", name).Error("Could not fetch tags")
 		return versioning.Notfound
@@ -75,13 +73,13 @@ func (r ImageRegistry) GetLatestVersion(name string) string {
 	return versioning.FindHighestVersionInList(tags, r.AllowAllReleases)
 }
 
-func (r ImageRegistry) fetch(pathSuffix string) ([]string, error) {
+func (r ImageRegistry) fetch(pathSuffix string, cacheToken string) ([]string, error) {
 	tags := []string{}
 
 	for {
 		var response tagsResponse
 		var err error
-		pathSuffix, err = r.getPaginatedJSON(pathSuffix, &response)
+		pathSuffix, err = r.getPaginatedJSON(pathSuffix, &response, cacheToken)
 		switch err {
 		case ErrNoMorePages:
 			tags = append(tags, response.Tags...)
@@ -95,8 +93,8 @@ func (r ImageRegistry) fetch(pathSuffix string) ([]string, error) {
 	}
 }
 
-func (r ImageRegistry) getPaginatedJSON(pathSuffix string, response interface{}) (string, error) {
-	client, req, err := r.getClientAndRequest(pathSuffix)
+func (r ImageRegistry) getPaginatedJSON(pathSuffix string, response interface{}, cacheToken string) (string, error) {
+	client, req, err := r.getClientAndRequest(pathSuffix, cacheToken)
 	if err != nil {
 		return "", err
 	}
@@ -117,7 +115,7 @@ func (r ImageRegistry) getPaginatedJSON(pathSuffix string, response interface{})
 	return getNextLink(resp)
 }
 
-func (r ImageRegistry) getClientAndRequest(pathSuffix string) (*http.Client, *http.Request, error) {
+func (r ImageRegistry) getClientAndRequest(pathSuffix string, cacheToken string) (*http.Client, *http.Request, error) {
 	url := fmt.Sprintf("https://%s%s", r.URL, pathSuffix)
 	log.WithField("url", url).Debugf("Try fetching url")
 	client := &http.Client{}
@@ -132,7 +130,8 @@ func (r ImageRegistry) getClientAndRequest(pathSuffix string) (*http.Client, *ht
 
 	if r.AuthType == AuthTypeToken && cacheToken == "" {
 		log.Debug("Need to fetch the auth token")
-		if err := r.getToken(url); err != nil {
+		err, cacheToken = r.getToken(url)
+		if err != nil {
 			return nil, nil, err
 		}
 	}
@@ -163,33 +162,33 @@ func getNextLink(resp *http.Response) (string, error) {
 	return "", ErrNoMorePages
 }
 
-func (r ImageRegistry) getToken(url string) error {
+func (r ImageRegistry) getToken(url string) (err error, cacheToken string) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return err
+		return err, ""
 	}
 
 	// Check if we need to login and find out the token url
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return err, ""
 	} else if resp.StatusCode != http.StatusUnauthorized {
-		return fmt.Errorf("Response code was not Unauthorized but [%v]", resp.StatusCode)
+		return fmt.Errorf("Response code was not Unauthorized but [%v]", resp.StatusCode), ""
 	}
 	defer resp.Body.Close()
 
 	// Get token url and login to get the token
 	tokenURL, err := parsHeaders(resp.Header)
 	if err != nil {
-		return err
+		return err, ""
 	}
 
 	log.WithField("url", tokenURL).Debug("Token url")
 	client = &http.Client{}
 	req, err = http.NewRequest("GET", tokenURL, nil)
 	if err != nil {
-		return err
+		return err, ""
 	}
 
 	if r.Username != "" || r.Password != "" {
@@ -198,9 +197,9 @@ func (r ImageRegistry) getToken(url string) error {
 
 	resp, err = client.Do(req)
 	if err != nil {
-		return err
+		return err, ""
 	} else if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Response code was not Oke but [%v]", resp.StatusCode)
+		return fmt.Errorf("Response code was not Oke but [%v]", resp.StatusCode), ""
 	}
 	defer resp.Body.Close()
 
@@ -208,15 +207,15 @@ func (r ImageRegistry) getToken(url string) error {
 	decoder := json.NewDecoder(resp.Body)
 	err = decoder.Decode(&authToken)
 	if err != nil {
-		return err
+		return err, ""
 	}
 
 	cacheToken = authToken.Token
-	return nil
+	return nil, cacheToken
 }
 
 type authToken struct {
-	Token string `json:"token"`
+	Token     string `json:"token"`
 }
 
 // example: Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="r.docker.io",scope="repository:library/ubuntu:pull"


### PR DESCRIPTION
- adding `/metrics` endpoint on port `9572`. 
- startup parameter to enable with with `--metrics`

example output for the tools
```
# HELP tool_info Information on tool releases
# TYPE tool_info gauge
tool_info{latestVersion="1.1.2",tool="mkdocs/mkdocs",version="1.1.1"} 0
tool_info{latestVersion="2.3.8",tool="wallabag/wallabag",version="2.3.8"} 1
tool_info{latestVersion="v0.12.26",tool="hashicorp/terraform",version="0.11.14"} 0
```

to have faster results I introduced goroutine for the `getLatestVersionsForContainers` function.
I needed to move the cacheToken away from a package wide var to a local var which is passed around.

Any changes you recommend?
Should I update the README? 