### PR TITLE
Add ca certificates to dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM alpine:3
-RUN apk --no-cache add ca-certificates && update-ca-certificates
+FROM alpine:3 as alpine
+RUN apk add -U --no-cache ca-certificates
+
+FROM scratch
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY k8s-platform-lcm /lcm
 COPY templates /templates
 COPY static /static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+FROM alpine:3
+RUN apk --no-cache add ca-certificates
 COPY k8s-platform-lcm /lcm
 COPY templates /templates
 COPY static /static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates && update-ca-certificates
 COPY k8s-platform-lcm /lcm
 COPY templates /templates
 COPY static /static


### PR DESCRIPTION
Currently I get errors while lcm is running:

```
time="2020-06-12T12:02:40Z" level=warning msg="Error fetching latest version: err: Get \"https://api.github.com/repos/hashicorp/terraform/releases/latest\": x509: certificate signed by unknown authority" repo=hashicorp/terraform
```

The reason for that is that the dockerimage doesn't contain the public ca certs and therefore can't trust the ssl connection.