### PR TITLE
fix(trivy): add support for registry auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
+	github.com/aquasecurity/fanal v0.0.0-20211224205755-c94f68b6d71a
 	github.com/aquasecurity/trivy v0.22.0
 	github.com/aws/aws-sdk-go v1.42.22
 	github.com/blang/semver/v4 v4.0.0
@@ -61,7 +62,6 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aquasecurity/cfsec v0.2.2 // indirect
 	github.com/aquasecurity/defsec v0.0.37 // indirect
-	github.com/aquasecurity/fanal v0.0.0-20211224205755-c94f68b6d71a // indirect
 	github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff // indirect
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce // indirect
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798 // indirect

--- a/internal/lcm.go
+++ b/internal/lcm.go
@@ -153,7 +153,7 @@ func getVulnerabilities(containerInfo []ContainerInfo, config config.Config) []C
 		xrayClient, err = xray.NewXray(config.Xray)
 		scannerIsXray = true
 	} else if len(config.Trivy.URL) > 0 {
-		trivyClient, err = trivy.NewTrivy(config.Trivy)
+		trivyClient, err = trivy.NewTrivy(config.Trivy, config.ImageRegistries)
 		scannerIsXray = false
 	}
 
@@ -169,7 +169,7 @@ func getVulnerabilities(containerInfo []ContainerInfo, config config.Config) []C
 			if scannerIsXray {
 				vulnera, err = xrayClient.GetVulnerabilities(ci.Container.Name, ci.Container.Version, config.Xray.Prefixes)
 			} else {
-				vulnera, err = trivyClient.GetVulnerabilities(ci.Container.FullPath)
+				vulnera, err = trivyClient.GetVulnerabilities(ci.Container.FullPath, ci.Container.Name, ci.Container.URL)
 			}
 			if err != nil {
 				log.WithError(err).WithField("image", ci.Container.Name).Warn("Could not fetch vulnerabilities")

--- a/internal/registries/images.go
+++ b/internal/registries/images.go
@@ -73,12 +73,12 @@ func (i *ImageRegistries) DefaultRegistries() {
 
 // GetLatestVersionForImage gets the latest version for image
 func (i ImageRegistries) GetLatestVersionForImage(name, url string) string {
-	registry := i.determinRegistry(name, url)
+	registry := i.DetermineRegistry(name, url)
 	name = i.findImageNameOverride(name)
 	return registry.GetLatestVersion(name)
 }
 
-func (i ImageRegistries) determinRegistry(name, url string) ImageRegistry {
+func (i ImageRegistries) DetermineRegistry(name, url string) ImageRegistry {
 	registry, exists := i.FindRegistryByOverrideByImage(name)
 	if exists {
 		return registry

--- a/internal/registries/images.go
+++ b/internal/registries/images.go
@@ -78,6 +78,8 @@ func (i ImageRegistries) GetLatestVersionForImage(name, url string) string {
 	return registry.GetLatestVersion(name)
 }
 
+// DetermineRegistry gets the approriate registry for an image/url,
+//  based on the override rules given within the config
 func (i ImageRegistries) DetermineRegistry(name, url string) ImageRegistry {
 	registry, exists := i.FindRegistryByOverrideByImage(name)
 	if exists {

--- a/internal/versioning/versioning.go
+++ b/internal/versioning/versioning.go
@@ -74,9 +74,9 @@ func FindHighestVersionInList(versions []string, allowAllReleases bool) string {
 	return Notfound
 }
 
-// DetermineLifeCycleStatus compares two versions to determin the status of the difference
+// DetermineLifeCycleStatus compares two versions to determine the status of the difference
 func DetermineLifeCycleStatus(latestVersion string, currentVersion string) string {
-	log.WithField("version", currentVersion).WithField("latestVersion", latestVersion).Debug("Determin status for version")
+	log.WithField("version", currentVersion).WithField("latestVersion", latestVersion).Debug("Determine status for version")
 	latest := strings.Split(version.Normalize(latestVersion), ".")
 	curr := strings.Split(version.Normalize(currentVersion), ".")
 

--- a/test.sh
+++ b/test.sh
@@ -42,7 +42,7 @@ fi
 
 if [[ ${LINTER} == true || ${RUNALL} == true ]]; then
   echo "Run golangci-lint"
-  golangci-lint run --timeout 3m
+  golangci-lint run --timeout 5m
 fi
 
 if [[ ${TESTS} == true || ${RUNALL} == true ]]; then


### PR DESCRIPTION
The trivy client needs to do docker registry lookups in order to
communicate details to the trivy server. This change passes through the
auth details from the `imageRegistries` portion in order to pass the
right authentication details to the trivy client.

In order to accomplish this, I made the determineRegistry function public, so it can be used from the trivy wrapper.