### PR TITLE
fix(k8s): image with sha digest panic handling

### DIFF
--- a/pkg/kubernetes/images.go
+++ b/pkg/kubernetes/images.go
@@ -23,15 +23,18 @@ func (c Image) WithoutLibrary() string {
 // ImagePathToImage converts image string to container information
 // In case of an error it returns an empty Image
 func ImagePathToImage(imagePath string) (Image, error) {
+	version := "0"
 	image, err := reference.ParseNormalizedNamed(imagePath)
 	if err != nil {
 		return Image{}, errors.Wrap(err, "Failed to pars image name")
 	}
 	image = reference.TagNameOnly(image) // adds tag latest if no tag is set
 
-	version := image.(reference.NamedTagged).Tag()
-	if version == "latest" {
-		version = "0" // tag 'latest' can't be compared
+	if !strings.Contains(imagePath, "@sha256:") {
+		version = image.(reference.NamedTagged).Tag()
+		if version == "latest" {
+			version = "0" // tag 'latest' can't be compared
+		}
 	}
 
 	return Image{

--- a/pkg/kubernetes/images_test.go
+++ b/pkg/kubernetes/images_test.go
@@ -53,3 +53,9 @@ func TestPodStringToPodStructWithPort(t *testing.T) {
 	expected := container("gcr.io:443/somebody/test:1.3", "gcr.io:443", "somebody/test", "1.3")
 	assert.Equal(t, expected, pod, "With port")
 }
+
+func TestPodStringToPodStructWithSha(t *testing.T) {
+	pod, _ := ImagePathToImage("gcr.io:443/somebody/test@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143")
+	expected := container("gcr.io:443/somebody/test@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143", "gcr.io:443", "somebody/test", "0")
+	assert.Equal(t, expected, pod, "With sha")
+}


### PR DESCRIPTION
closes: https://github.com/arminc/k8s-platform-lcm/issues/31

This essentially side steps the panic issue here with a sha digest by just setting the version to `0`. I spent some time trying to figure out a better work around by looking at [the upstream function ParseAnyReference](https://pkg.go.dev/github.com/docker/distribution/reference#ParseAnyReferenceWithSet) but that resulted in the same issue. TLDR: the sha is not considered a tag, so when `.Tag()` is called it's not happy.

I'm not sure what the default should be when the tool cannot find a tag. maybe `999`? just something that might standout and not be overloaded with `latest`

The upstream module looks like it also moved to [distribution/distribution/reference](https://github.com/distribution/distribution) instead of `docker/distribution/reference`

---
Another option that may or may not be preferable is to give the ability to excludeNamespaces or specific containers in the config. That would bring more changes in the config package though.